### PR TITLE
Handle multiple issues for an alert

### DIFF
--- a/pkg/notifier/github.go
+++ b/pkg/notifier/github.go
@@ -52,6 +52,12 @@ func (n *GitHubNotifier) Notify(ctx context.Context, payload *types.WebhookPaylo
 	} else if searchResult.GetTotal() > 1 {
 		log.Warn().Interface("searchResultTotal", searchResult.GetTotal()).
 			Str("groupKey", payload.GroupKey).Msg("too many search result")
+
+		for _, i := range searchResult.Issues {
+			if issue == nil || issue.GetCreatedAt().Before(i.GetCreatedAt()) {
+				issue = i
+			}
+		}
 	}
 
 	body, err := n.BodyTemplate.Execute(payload)


### PR DESCRIPTION
Basically, only one GitHub issue exists for each alert ID but if multiple alerts arrive concurrently, multiple GitHub issues can be created. This PR addresses the problem.

- 0c86d172efdffbd4ef56b4fd952706108049c5ff If multi issues exist, update the latest-created issue.
- f01227941a16a3bfdae9ce3671df6e3c950e57b1 If multi issues exist, close old issues and put a link to the latest one.