### PR TITLE
Add multi-arch support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,15 +22,16 @@ RUN --mount=target=. \
     go test -v ./...
 
 FROM base AS build
+ARG TARGETOS TARGETARCH
 RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build -o /out/alertmanager-to-github .
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /out/alertmanager-to-github .
 
 FROM scratch AS export
 COPY --from=build /out/alertmanager-to-github /
 
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot-${TARGETARCH}
 COPY --from=build /out/alertmanager-to-github /
 ENTRYPOINT ["/alertmanager-to-github"]
 CMD ["start"]


### PR DESCRIPTION
This PR adds multi-arch support.

I've tried this PR in my personal image registry and checked it works well.

- https://github.com/users/superbrothers/packages/container/package/alertmanager-to-github

```
$ uname -a
Linux pi10 5.13.0-1022-raspi #24-Ubuntu SMP PREEMPT Wed Mar 16 07:19:33 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux
$ sudo docker run --rm -it ghcr.io/superbrothers/alertmanager-to-github:v0.0.2.pre2-13-ge2719be-dirty --help
ghcr.io/superbrothers/alertmanager-to-github:v0.0.2.pre2-13-ge2719be-dirty:       resolved       |++++++++++++++++++++++++++++++++++++++|
index-sha256:a5c780682f52ad647a13f17272022e8161da1385b68bf22cd2977ce9a2d95420:    done           |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:4834759401de6758eba68781d3d9ec3948f115fbec91e10a49f090c2a8ea39ee: done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:18ae2412446abce699dafa68ba8adb7b58ea21f1b018a01acdf33eb026e3774d:   done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:77a64c1c458711cad96b5b30bc606aef5d83ef47952ef79cd01dd7f80419a029:    done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 5.2 s                                                                    total:  8.4 Mi (1.6 MiB/s)
NAME:
   /alertmanager-to-github - Webhook receiver Alertmanager to create GitHub issues

USAGE:
   /alertmanager-to-github [global options] command [command options] [arguments...]

COMMANDS:
   start          Start webhook HTTP server
   test-template  Test rendering a template
   help, h        Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h  show help (default: false)
```