### PR TITLE
Use ghcr.io for image registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-TAG=$(shell git describe --tags --always --dirty)
-IMAGE=internal-registry.example.com/alertmanager-to-github:$(TAG)
+TAG := $(shell git describe --tags --always --dirty)
+IMAGE ?= ghcr.io/pfnet-research/alertmanager-to-github:$(TAG)
 ARCH ?= amd64
 ALL_ARCH ?= amd64 arm64
 


### PR DESCRIPTION
With this PR, this project changes to use ghcr.io for image registry.

The image registry present in the manifest file will be updated for the next release.

- https://github.com/pfnet-research/alertmanager-to-github/blob/master/example/kubernetes/deploy.yaml#L16