### PR TITLE
Fix a failure to build arm64 image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,4 +20,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: make docker-build
+    - run: make docker-build-all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1
-FROM golang:1.18 AS base
+FROM --platform=$BUILDPLATFORM golang:1.18 AS base
 WORKDIR /workspace
 ENV CGO_ENABLED=0
 COPY go.* .
@@ -31,7 +31,7 @@ RUN --mount=target=. \
 FROM scratch AS export
 COPY --from=build /out/alertmanager-to-github /
 
-FROM gcr.io/distroless/static:nonroot-${TARGETARCH}
+FROM --platform=$BUILDPLATFORM gcr.io/distroless/static:nonroot
 COPY --from=build /out/alertmanager-to-github /
 ENTRYPOINT ["/alertmanager-to-github"]
 CMD ["start"]


### PR DESCRIPTION
This PR fixes a failure to build arm64 image. In addition to amd64, CI workflow should build an image for arm64 so that we are aware of the same problem. Because of the small size of this application, building images for all archs will not increase CI time much.