### PR TITLE
Support disabling of auto-closing resolved issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 This receives webhook requests from Alertmanager and creates GitHub issues.
 
 It does:
-* open an issue on a new alert
-* close the issue when the alert is in resolved status
-* reopen the issue when the alert is in firing status
-  * alerts are identified by `groupKey`; configurable via `--alert-id-template` option
+
+- open an issue on a new alert
+- close the issue when the alert is in resolved status
+- reopen the issue when the alert is in firing status
+  - alerts are identified by `groupKey`; configurable via `--alert-id-template` option
 
 <kbd>![screen shot](doc/screenshot.png)</kbd>
 
@@ -14,13 +15,13 @@ It does:
 
 ### Docker image
 
-```
+```shell
 docker pull ghcr.io/pfnet-research/alertmanager-to-github:v0.0.2
 ```
 
 ### go get
 
-```
+```shell
 go get github.com/pfnet-research/alertmanager-to-github
 ```
 
@@ -28,7 +29,7 @@ go get github.com/pfnet-research/alertmanager-to-github
 
 Start webhook server:
 
-```
+```shell
 $ read ATG_GITHUB_TOKEN
 (Personal Access Token)
 $ export ATG_GITHUB_TOKEN
@@ -40,19 +41,19 @@ Add a receiver to Alertmanager config:
 
 ```yaml
 route:
-  receiver: 'togithub' # default
+  receiver: "togithub" # default
 
 receivers:
-- name: "togithub"
-  webhook_configs:
-  # Create issues in "bar" repo in "foo" organization.
-  # repo and owner parameters must be URL-encoded.
-  - url: 'http://localhost:8080/v1/webhook?owner=foo&repo=bar'
+  - name: "togithub"
+    webhook_configs:
+      # Create issues in "bar" repo in "foo" organization.
+      # repo and owner parameters must be URL-encoded.
+      - url: "http://localhost:8080/v1/webhook?owner=foo&repo=bar"
 ```
 
 ## Configuration
 
-```
+```shell
 $ alertmanager-to-github start -h
 NAME:
    alertmanager-to-github start - Start webhook HTTP server
@@ -68,6 +69,7 @@ OPTIONS:
    --title-template-file value  Title template file [$ATG_TITLE_TEMPLATE_FILE]
    --alert-id-template value    Alert ID template (default: "{{.Payload.GroupKey}}") [$ATG_ALERT_ID_TEMPLATE]
    --github-token value         GitHub API token (command line argument is not recommended) [$ATG_GITHUB_TOKEN]
+   --auto-close-resolved-issues Close resolved issues automatically (default: true) [$ATG_AUTO_CLOSE_RESOLVED_ISSUES]
    --help, -h                   show help (default: false)
 ```
 
@@ -79,12 +81,12 @@ To create issues in GHE, set `--github-url` option or `ATG_GITHUB_URL` environme
 
 Issue title and body are rendered from [Go template](https://golang.org/pkg/text/template/) and you can use custom templates via `--body-template-file` and `--title-template-file` options. In the templates, you can use the following variables and functions.
 
-* Variables
-    * `.Payload`: Webhook payload incoming to this receiver. For more information, see `WebhookPayload` in [pkg/types/payload.go](https://github.com/pfnet-research/alertmanager-to-github/blob/master/pkg/types/payload.go)
-* Functions
-    * `urlQueryEscape`: Escape a string as a URL query
-    * `json`: Marshal an object to JSON string
-    * `timeNow`: Get current time
+- Variables
+  - `.Payload`: Webhook payload incoming to this receiver. For more information, see `WebhookPayload` in [pkg/types/payload.go](https://github.com/pfnet-research/alertmanager-to-github/blob/master/pkg/types/payload.go)
+- Functions
+  - `urlQueryEscape`: Escape a string as a URL query
+  - `json`: Marshal an object to JSON string
+  - `timeNow`: Get current time
 
 ## Deployment
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -28,6 +28,7 @@ const flagGitHubToken = "github-token"
 const flagAlertIDTemplate = "alert-id-template"
 const flagTemplateFile = "template-file"
 const flagPayloadFile = "payload-file"
+const flagAutoCloseResolvedIssues = "auto-close-resolved-issues"
 
 const defaultPayload = `{
   "version": "4",
@@ -147,6 +148,13 @@ func App() *cli.App {
 						Usage:    "GitHub API token (command line argument is not recommended)",
 						EnvVars:  []string{"ATG_GITHUB_TOKEN"},
 					},
+					&cli.BoolFlag{
+						Name:     flagAutoCloseResolvedIssues,
+						Required: false,
+						Value: true,
+						Usage:    "Should issues be automatically closed when resolved",
+						EnvVars:  []string{"ATG_AUTO_CLOSE_RESOLVED_ISSUES"},
+					},
 				},
 			},
 			{
@@ -260,6 +268,7 @@ func actionStart(c *cli.Context) error {
 	nt.BodyTemplate = bodyTemplate
 	nt.TitleTemplate = titleTemplate
 	nt.AlertIDTemplate = alertIDTemplate
+	nt.AutoCloseResolvedIssues = c.Bool(flagAutoCloseResolvedIssues)
 
 	router := server.New(nt).Router()
 	if err := router.Run(c.String(flagListen)); err != nil {


### PR DESCRIPTION
Adds the flag: --auto-close-resolved-issues to control this behaviour.

Closes https://github.com/pfnet-research/alertmanager-to-github/issues/17.
