### PR TITLE
Change the label names for customizing org and/or repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Issue title and body are rendered from [Go template](https://golang.org/pkg/text
   - `json`: Marshal an object to JSON string
   - `timeNow`: Get current time
 
-## Customize organisation and repository
+## Customize organization and repository
 
-The organisation/repository where issues are raised can be customised per-alert by specifying the `owner` and/or `repo` labels on the alert.
+The organization/repository where issues are raised can be customized per-alert by specifying the `atg_owner` label for the organization and/or the `atg_repo` label for the repository on the alert.
 
 e.g.
 
@@ -101,8 +101,8 @@ e.g.
   for: 10m
   labels:
     severity: page
-    org: my-alternative-org
-    repo: specific-service-repository
+    atg_owner: my-alternative-org
+    atg_repo: specific-service-repository
   annotations:
     summary: High request latency
 ```

--- a/pkg/notifier/github.go
+++ b/pkg/notifier/github.go
@@ -17,6 +17,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	ownerLabelName = "atg_owner"
+	repoLabelName  = "atg_repo"
+)
+
 var (
 	rateLimit = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -70,11 +75,11 @@ func resolveRepository(payload *types.WebhookPayload, queryParams url.Values) (e
 	owner := queryParams.Get("owner")
 	repo := queryParams.Get("repo")
 
-	if payload.CommonLabels["owner"] != "" {
-		owner = payload.CommonLabels["owner"]
+	if payload.CommonLabels[ownerLabelName] != "" {
+		owner = payload.CommonLabels[ownerLabelName]
 	}
-	if payload.CommonLabels["repo"] != "" {
-		repo = payload.CommonLabels["repo"]
+	if payload.CommonLabels[repoLabelName] != "" {
+		repo = payload.CommonLabels[repoLabelName]
 	}
 	if owner == "" {
 		return fmt.Errorf("owner was not specified in either the webhook URL, or the alert labels"), "", ""


### PR DESCRIPTION
The current label names used for customizing GitHub organization and/or
repository are `owner` and `repo`, which are generic names that may be
unintentionally targeted by this feature. To avoid this, add the `atg_`
prefix and make it work only when intended.

## REF

- https://github.com/pfnet-research/alertmanager-to-github/issues/15