### PR TITLE
Bump the version to v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It does:
 ### Docker image
 
 ```shell
-docker pull ghcr.io/pfnet-research/alertmanager-to-github:v0.0.2
+docker pull ghcr.io/pfnet-research/alertmanager-to-github:v0.1.0
 ```
 
 ### go get

--- a/example/kubernetes/deployment.yaml
+++ b/example/kubernetes/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: alertmanager-to-github
-        image: ghcr.io/superbrothers/alertmanager-to-github:v0.0.2
+        image: ghcr.io/superbrothers/alertmanager-to-github:v0.1.0
         env:
         - name: ATG_LISTEN
           value: ':8080'


### PR DESCRIPTION
This PR bumps the version of alertmanager-to-github to v0.1.0. After this PR is merged, I'll create the git tag `v0.1.0`.