### PR TITLE
Fix the wrong container image in the example manifest

### DIFF
--- a/example/kubernetes/deployment.yaml
+++ b/example/kubernetes/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: alertmanager-to-github
-        image: ghcr.io/superbrothers/alertmanager-to-github:v0.1.0
+        image: ghcr.io/pfnet-research/alertmanager-to-github:v0.1.0
         env:
         - name: ATG_LISTEN
           value: ':8080'


### PR DESCRIPTION
This PR fixes the wrong container image in the example manifest.

```
$ crane ls ghcr.io/pfnet-research/alertmanager-to-github
v0.0.2-amd64
v0.0.2-arm64
v0.0.2
v0.1.0-amd64
v0.1.0-arm64
```