### PR TITLE
Update tagpr workflow to trigger a job when PR is (un)labeled

### DIFF
--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -3,6 +3,9 @@ name: tagpr
 on:
   push:
     branches: ["master"]
+  pull_request:
+    types: ["labeled", "unlabeled"]
+    branches: ["tagpr-from-v*"]
 
 jobs:
   tagpr:


### PR DESCRIPTION
This PR updates tagpr workflow to trigger a job when PR is (un)labeled.

Even if we add `tagpr:minor` label to a PR,  tagpr workflow job will not be executed, so we need to trigger it manually. This PR automates that.

## REF

- https://github.com/pfnet-research/alertmanager-to-github/pull/47#issuecomment-2782151456