### PR TITLE
Fix "skip auto close" annotation key

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ OPTIONS:
    --github-app-installation-id value  GitHub App installation ID (default: 0) [$ATG_GITHUB_APP_INSTALLATION_ID]
    --github-app-private-key value      GitHub App private key (command line argument is not recommended) [$ATG_GITHUB_APP_PRIVATE_KEY]
    --github-token value                GitHub API token (command line argument is not recommended) [$ATG_GITHUB_TOKEN]
-   --auto-close-resolved-issues        Should issues be automatically closed when resolved. If alerts have 'atg-skip-auto-close=true' annotation, issues will not be auto-closed. (default: true) [$ATG_AUTO_CLOSE_RESOLVED_ISSUES]
+   --auto-close-resolved-issues        Should issues be automatically closed when resolved. If alerts have 'atg_skip_auto_close=true' annotation, issues will not be auto-closed. (default: true) [$ATG_AUTO_CLOSE_RESOLVED_ISSUES]
    --reopen-window value               Alerts will create a new issue instead of reopening closed issues if the specified duration has passed [$ATG_REOPEN_WINDOW]
    --help, -h                          show help
 ```
@@ -110,7 +110,7 @@ Issue title and body are rendered from [Go template](https://golang.org/pkg/text
 
 You can use the `--auto-close-resolved-issues` flag to automatically close issues when alerts are resolved.
 
-If you want to skip auto-close for some alerts, add the `atg-skip-auto-close=true` annotation to them.
+If you want to skip auto-close for some alerts, add the `atg_skip_auto_close=true` annotation to them.
 
 ```yaml
 - alert: HighRequestLatency
@@ -118,7 +118,7 @@ If you want to skip auto-close for some alerts, add the `atg-skip-auto-close=tru
   labels:
     severity: critical
   annotations:
-    atg-skip-auto-close: "true"
+    atg_skip_auto_close: "true"
 ```
 
 ## Customize organization and repository

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -182,7 +182,7 @@ func App() *cli.App {
 						Name:     flagAutoCloseResolvedIssues,
 						Required: false,
 						Value:    true,
-						Usage:    "Should issues be automatically closed when resolved. If alerts have 'atg-skip-auto-close=true' annotation, issues will not be auto-closed.",
+						Usage:    "Should issues be automatically closed when resolved. If alerts have 'atg_skip_auto_close=true' annotation, issues will not be auto-closed.",
 						EnvVars:  []string{"ATG_AUTO_CLOSE_RESOLVED_ISSUES"},
 					},
 					&noDefaultDurationFlag{

--- a/pkg/cli/templates/body.tmpl
+++ b/pkg/cli/templates/body.tmpl
@@ -57,7 +57,7 @@ Previous Issue: {{ $previousIssue.HTMLURL }}
 
 {{- if $payload.HasSkipAutoCloseAnnotation }}
 
-*This issue will not be auto-closed because the alerts have `atg-skip-auto-close=true` annotation.*
+*This issue will not be auto-closed because the alerts have `atg_skip_auto_close=true` annotation.*
 {{- end }}
 
 <!-- alert data: {{json $payload}} -->

--- a/pkg/types/payload.go
+++ b/pkg/types/payload.go
@@ -11,7 +11,7 @@ const (
 	AlertStatusResolved AlertStatus = "resolved"
 	AlertStatusFiring   AlertStatus = "firing"
 
-	skipAutoCloseAnnotationKey   = "atg-skip-auto-close"
+	skipAutoCloseAnnotationKey   = "atg_skip_auto_close"
 	skipAutoCloseAnnotationValue = "true"
 )
 

--- a/pkg/types/payload_test.go
+++ b/pkg/types/payload_test.go
@@ -28,7 +28,7 @@ func TestWebhookPayloadHasSkipAutoCloseAnnotation(t *testing.T) {
 			payload: &WebhookPayload{
 				Alerts: []WebhookAlert{{
 					Annotations: map[string]string{
-						"atg-skip-auto-close": "true",
+						"atg_skip_auto_close": "true",
 					},
 				}},
 			},
@@ -69,7 +69,7 @@ func TestWebhookPayloadHasSkipAutoCloseAnnotation(t *testing.T) {
 				Alerts: []WebhookAlert{
 					{
 						Annotations: map[string]string{
-							"atg-skip-auto-close": "true",
+							"atg_skip_auto_close": "true",
 						},
 					},
 					{


### PR DESCRIPTION
This PR fixes "atg-skip-auto-close" annotation key to `atg_skip_auto_close`.

In Prometheus, `-` is not allowed in label and annotation key.

> Prometheus metrics and label names are written in snake_case. Converting camelCase to snake_case is desirable, though doing so automatically doesn’t always produce nice results for things like myTCPExample or isNaN so sometimes it’s best to leave them as-is.

https://prometheus.io/docs/instrumenting/writing_exporters/#naming

