### PR TITLE
Suppress warning messages about gin mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,6 @@ COPY --from=build /out/alertmanager-to-github /
 
 FROM --platform=$BUILDPLATFORM gcr.io/distroless/static:nonroot
 COPY --from=build /out/alertmanager-to-github /
+ENV GIN_MODE=release
 ENTRYPOINT ["/alertmanager-to-github"]
 CMD ["start"]


### PR DESCRIPTION
This PR suppresses warning messages about gin mode.

Closes https://github.com/pfnet-research/alertmanager-to-github/issues/56

